### PR TITLE
Fixed all the 'definitely lost' and 'indirectly lost' memory leaks.

### DIFF
--- a/bwt.cpp
+++ b/bwt.cpp
@@ -15,10 +15,10 @@ int main(int argc, char **argv) {
 
     if (!op.compare("-test")) {
         string *input = read_fasta(const_cast<char*>("sonnet1.fasta"));
-        string *input_bwt = bwt(input);
-        string *input_ibwt = ibwt(input_bwt);
+        string input_bwt = bwt(*input);
+        string *input_ibwt = ibwt(&input_bwt);
         string *output = read_fasta(const_cast<char*>("sonnet1.bwt.fasta"));
-        assert(*input_bwt == *output);
+        assert(input_bwt == *output);
         assert(*input_ibwt == *input);
         cout << "OK" << endl;
         exit(0);
@@ -41,27 +41,29 @@ int main(int argc, char **argv) {
     if (invert) {
         write_fasta(output, ibwt(input), "inverse BWT of " + string(argv[2]));
     } else {
-        write_fasta(output, bwt(input), "BWT of " + string(argv[2]));
+    	string s = bwt(*input);
+        write_fasta(output, &s, "BWT of " + string(argv[2]));
     }
     return 0;
 }
 
-string *bwt(string *input) {
+string bwt(string &input) {
     size_t sz;
     uint32_t *sa = gen_suffix_array(input, &sz);
 
     /* construct bwt from suffix array */
-    char *bwt = new char[input->length()];
+    char *bwt = new char[input.length()];
     char *orig = bwt;
-    for (size_t i = 1; i <= input->length(); i++) {
+    for (size_t i = 1; i <= input.length(); i++) {
         if (sa[i] > 0) {
-            *bwt++ = input->at(sa[i] - 1);
+            *bwt++ = input.at(sa[i] - 1);
         } else {
-            *bwt++ = input->at(input->length() - 1);
+            *bwt++ = input.at(input.length() - 1);
         }
     }
 
-    return new string(orig, bwt - orig);
+    delete[] sa;
+    return std::string(orig, bwt - orig);
 }
 
 string *ibwt(string *L) {

--- a/bwt.cpp
+++ b/bwt.cpp
@@ -1,53 +1,56 @@
 // Copyright 2012 Eric Liang
 
+#include "bwt.h"
+#include "fasta.h"
+
 #include <iostream>
 #include <assert.h>
 
-#include "fasta.h"
-#include "bwt.h"
 
 using std::cout;
 using std::endl;
 
 int main(int argc, char **argv) {
-    assert(argc > 1);
-    string op = string(argv[1]);
+   assert(argc > 1);
+   string op = string(argv[1]);
 
-    if (!op.compare("-test")) {
-        string *input = read_fasta(const_cast<char*>("sonnet1.fasta"));
-        string input_bwt = bwt(*input);
-        string *input_ibwt = ibwt(&input_bwt);
-        string *output = read_fasta(const_cast<char*>("sonnet1.bwt.fasta"));
-        assert(input_bwt == *output);
-        assert(*input_ibwt == *input);
-        cout << "OK" << endl;
-        exit(0);
-    }
+   if (!op.compare("-test")) {
+       string input = read_fasta(const_cast<char*>("sonnet1.fasta"));
+       string input_bwt = bwt(input);
+       string input_ibwt = ibwt(&input_bwt);
+       string output = read_fasta(const_cast<char*>("sonnet1.bwt.fasta"));
+       assert(input_bwt == output);
+       assert(input_ibwt == input);
+       cout << "OK" << endl;
+       exit(0);
+   }
 
-    assert(argc == 4);
-    bool invert = false;
+   assert(argc == 4);
+   bool invert = false;
 
-    if (!op.compare("-bwt")) {
-        invert = false;
-    } else if (!op.compare("-ibwt")) {
-        invert = true;
-    } else {
-        assert(!"unknown op");
-    }
+   if (!op.compare("-bwt")) {
+       invert = false;
+   } else if (!op.compare("-ibwt")) {
+       invert = true;
+   } else {
+       assert(!"unknown op");
+   }
 
-    string *input = read_fasta(argv[2]);
-    string output = string(argv[3]);
+   string input = read_fasta(argv[2]);
+   string output = string(argv[3]);
 
-    if (invert) {
-        write_fasta(output, ibwt(input), "inverse BWT of " + string(argv[2]));
-    } else {
-    	string s = bwt(*input);
-        write_fasta(output, &s, "BWT of " + string(argv[2]));
-    }
-    return 0;
+   string ibwt_input = ibwt(&input);
+   string bwt_input = bwt(input);
+
+   if (invert) {
+       write_fasta(output, &ibwt_input, "inverse BWT of " + string(argv[2]));
+   } else {
+       write_fasta(output, &bwt_input, "BWT of " + string(argv[2]));
+   }
+   return 0;
 }
 
-string bwt(string &input) {
+string bwt(string& input) {
     size_t sz;
     uint32_t *sa = gen_suffix_array(input, &sz);
 
@@ -62,11 +65,16 @@ string bwt(string &input) {
         }
     }
 
+    std::string s(orig, bwt - orig);
     delete[] sa;
-    return std::string(orig, bwt - orig);
+    bwt = orig;
+    delete[] bwt;
+    orig = nullptr;
+    delete orig;
+    return s;
 }
 
-string *ibwt(string *L) {
+string ibwt(string *L) {
     char *F = new char[L->length()];
     uint32_t *C = new uint32_t[L->length()];
     char_sort_to(L->c_str(), L->length(), F);
@@ -102,8 +110,8 @@ string *ibwt(string *L) {
 
     delete[] F;
     delete[] C;
-    string *s = new string(buf, L->length());
+
+    std::string s(buf, L->length());
     delete[] buf;
     return s;
 }
-

--- a/bwt.h
+++ b/bwt.h
@@ -7,12 +7,12 @@
 #include <inttypes.h>
 #include <memory.h>
 
-#include "suffix_array.h"
 #include "sorts.h"
+#include "suffix_array.h"
 
 using std::string;
 
-string bwt(string &input);
-string *ibwt(string *L);
+string bwt(string& input);
+string ibwt(string *L);
 
 #endif  // BWT_H_

--- a/bwt.h
+++ b/bwt.h
@@ -12,7 +12,7 @@
 
 using std::string;
 
-string *bwt(string *input);
+string bwt(string &input);
 string *ibwt(string *L);
 
 #endif  // BWT_H_

--- a/fasta.cpp
+++ b/fasta.cpp
@@ -6,7 +6,7 @@ using std::ios;
 using std::ofstream;
 using std::endl;
 
-string *read_fasta(char *filepath) {
+string read_fasta(char *filepath) {
     struct stat st;
     stat(filepath, &st);
 
@@ -52,7 +52,7 @@ string *read_fasta(char *filepath) {
         }
     }
 
-    return new string(data, writeptr - data - 1);
+    return string(data, writeptr - data - 1);
 }
 
 void write_fasta(string filepath, string *seq, string comment) {

--- a/fasta.h
+++ b/fasta.h
@@ -18,7 +18,7 @@ using std::string;
 /**
  * Returns string with contents of fasta sequence
  */
-string *read_fasta(char *filepath);
+string read_fasta(char *filepath);
 
 /**
  * Writes sequence and comment to output file

--- a/suffix_array.cpp
+++ b/suffix_array.cpp
@@ -175,12 +175,13 @@ uint32_t *ranks(const char *T, size_t sz) {
     }
 
     delete[] arr;
+    delete[] rank;
     return rr;
 }
 
-uint32_t *gen_suffix_array(string *input, size_t *retsz) {
-    uint32_t *v = ranks(input->c_str(), input->length());
-    uint32_t *sa = idc3(v, input->length(), retsz);
+uint32_t *gen_suffix_array(string &input, size_t *retsz) {
+    uint32_t *v = ranks(input.c_str(), input.length());
+    uint32_t *sa = idc3(v, input.length(), retsz);
     delete[] v;
     return sa;
 }

--- a/suffix_array.h
+++ b/suffix_array.h
@@ -24,6 +24,6 @@
 #define vprint(x, v, sz)
 #endif
 
-uint32_t *gen_suffix_array(string *input, size_t *retsz);
+uint32_t *gen_suffix_array(string &input, size_t *retsz);
 
 #endif  // SUFFIX_ARRAY_H_


### PR DESCRIPTION
Hi! Sorry for the late pull request Eric. I copied the results of the following command below:

valgrind --leak-check=yes ./bwt -test

Leak summary before:
==6103==    definitely lost: 459 bytes in 2 blocks
==6103==    indirectly lost: 476 bytes in 1 blocks
==6103==      possibly lost: 1,458 bytes in 4 blocks
==6103==    still reachable: 72,720 bytes in 3 blocks
==6103==         suppressed: 0 bytes in 0 blocks

Leak summary after:
==6633==    definitely lost: 0 bytes in 0 blocks
==6633==    indirectly lost: 0 bytes in 0 blocks
==6633==      possibly lost: 1,934 bytes in 5 blocks
==6633==    still reachable: 72,704 bytes in 1 blocks
==6633==         suppressed: 0 bytes in 0 blocks

There may still be some leaks but at least we got rid of definitely lost and indirectly lost leaks.
Thank you again!